### PR TITLE
update commitlint husky integration art

### DIFF
--- a/content/post/enforce-git-commit-message-format.md
+++ b/content/post/enforce-git-commit-message-format.md
@@ -50,7 +50,7 @@ And add a script to `package.json`:
 
 ```json
 "scripts": {
-  "commitmsg": "commitlint -e",
+  "commitmsg": "commitlint -e $GIT_PARAMS",
 }
 ```
 


### PR DESCRIPTION
This updates the `husky` - `commitlint` integration example to recommended version as of `commitlint@4.2`